### PR TITLE
Center-align lab slots and lunch column in timetable UI and PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,27 @@
         	html: source,  //sets the id of the table to be downloaded
         	startY: 70,
         	theme: 'grid',
+
+           // jsPDF autoTable ignores CSS for merged cells (colspan).
+           // Force horizontal and vertical centering for 3-hour lab slots in PDF export.
+           // Force horizontal and vertical centering for lunch slot in PDF export.
+
+            didParseCell: function (data) {
+                const cell = data.cell;
+
+                // Center lab slots (3-hour blocks)
+                if (cell.colSpan === 3) {
+                    cell.styles.halign = 'center';
+                    cell.styles.valign = 'middle';
+                }
+
+                // Center LUNCH column (rowspan across days)
+                if (cell.rowSpan === 6) {
+                    cell.styles.halign = 'center';
+                    cell.styles.valign = 'middle';
+                }
+            },
+
         	columnStyles: {
         	    0: {
         	        cellWidth: 75,

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,20 @@
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300);
 
+/* Center-align 3-hour lab slots (P/Q/R/S/T) in the timetable UI.
+   These cells span multiple periods using colspan=3. */
+td[colspan="3"] {
+    text-align: center;
+    vertical-align: middle;
+    font-weight: 500;
+}
+
+/* Center-align the LUNCH column across all days (rowspan=6) */
+.lunch {
+    text-align: center;
+    vertical-align: middle;
+}
+
+
 /* body{
 
     background-color:#fae0e4;


### PR DESCRIPTION
This PR fixes alignment issues for merged timetable cells.

- Center-aligns 3-hour lab slots (P/Q/R/S/T) across their full span in the UI using CSS.
- Ensures correct horizontal and vertical centering for lab slots in PDF export via jsPDF autoTable.
- Centers the LUNCH column across all days in both the UI and PDF export.

These changes improve visual consistency between the web view and the downloaded PDF.
